### PR TITLE
chore(pom): change push repo to Artifactory directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ You can override some default behaviours through the usage of the command line p
     <th>Property</th><th>Description</th>
   </tr>
   <tr>
-    <td>nexus.snapshot.repository</td><td>Specify the url to your snapshot repository.<br/>Default is <strong>https://app.camunda.com/nexus/content/repositories/camunda-bpm</strong>.</td>
+    <td>nexus.snapshot.repository</td><td>Specify the url to your snapshot repository.<br/>Default is <strong>https://camunda.jfrog.io/artifactory/camunda-bpm-snapshots</strong>.</td>
   </tr>
   <tr>
-    <td>nexus.release.repository</td><td>Specify the url to your release repository.<br/>Default is <strong>https://app.camunda.com/nexus/content/repositories/camunda-bpm</strong>.</td>
+    <td>nexus.release.repository</td><td>Specify the url to your release repository.<br/>Default is <strong>https://camunda.jfrog.io/artifactory/camunda-bpm</strong>.</td>
   </tr>
   <tr>
     <td>skip.nexus.release</td><td>When setting the value to true, skip the deployment to the release repository specified in <distributionManagement>.<br/>Default is <strong>false</strong>.</td>

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
     <skip.camunda.release>false</skip.camunda.release>
     <skip.central.release>false</skip.central.release>
     <nexus.snapshot.repository.id>camunda-nexus</nexus.snapshot.repository.id>
-    <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/camunda-bpm-snapshots</nexus.snapshot.repository>
+    <nexus.snapshot.repository>https://camunda.jfrog.io/artifactory/camunda-bpm-snapshots</nexus.snapshot.repository>
     <nexus.release.repository.id>camunda-nexus</nexus.release.repository.id>
-    <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/camunda-bpm</nexus.release.repository>
+    <nexus.release.repository>https://camunda.jfrog.io/artifactory/camunda-bpm</nexus.release.repository>
 
     <nexus.staging.deploy.id>camunda-nexus</nexus.staging.deploy.id>
-    <nexus.staging.deploy.url>https://app.camunda.com/nexus</nexus.staging.deploy.url>
+    <nexus.staging.deploy.url>https://camunda.jfrog.io/artifactory</nexus.staging.deploy.url>
     <nexus.sonatype.url>https://oss.sonatype.org</nexus.sonatype.url>
     <gpg.useagent>true</gpg.useagent>
 


### PR DESCRIPTION
changed it already for 3.7, so AP can use it.
Persisting the change so other projects depending on it will bypass the proxy and directly upload to Artifactory.