### PR TITLE
feat: add central-sonatype-publish profile for Sonatype Central Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,173 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.camunda/camunda-release-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.camunda/camunda-release-parent)
 
-camunda-release-parent
-======================
 
-Pom which can be inherited for camunda releases defining some common release properties.
-It allows to deploy to two repositories simultaneously. One is a Nexus OSS server, the other one a Nexus Enterprise server.
-It will deploy the artifacts at the end of the build to keep the window of failure small when talking to external systems.
+# camunda-release-parent
 
-Usage
------
+> [!WARNING]
+> ## Migration to Sonatype Central Portal
+>
+> Sonatype is deprecating the legacy [OSSRH](https://central.sonatype.org/news/20250326_ossrh_sunset/) service and moving all artifact publishing to the new [Central Portal](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/).
+>
+> This migration affects all **Camunda namespaces** including `io.camunda` and `org.camunda`.
+>
+> ❗ **Important:** The migration is **one-way**. Once a namespace is migrated, publishing via OSSRH will **no longer be possible**.
+>
+> ### What Changed in this Parent POM?
+>
+> To support the migration, this parent POM (starting from version `3.10.0`) includes:
+>
+> - ✅ **`central-sonatype-publish`**, a new Maven profile for publishing via the Central Portal
+>   - uses `central-publishing-maven-plugin` (replaces the deprecated `nexus-staging-maven-plugin`)  
+>   - reuses the same configurations as in `sonatype-oss-release` profile
+> - ⚠️ **`sonatype-oss-release`**, now marked as **deprecated**
+>
+> 🚨 Projects can upgrade to this new minor version at any time, but the `central-sonatype-publish` profile should only be used after the namespace migration has taken place.
+>
+> ### What Will Happen on Migration Day?
+>
+> 📅 Refer to internal communication for the migration date and status.
+>
+> Once your namespace has been migrated:  
+> - OSSRH publishing will no longer work  
+>
+> At the same time, we will release a new `4.0.0` version of this parent POM, which:
+>
+> - makes `central-sonatype-publish` the **default profile** used by `maven-release-plugin`
+> - reconfigures the deprecated `sonatype-oss-release` profile and `nexus-staging-maven-plugin` to use Sonatype’s Central [Portal OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/), which is a **partial** reimplementation of the legacy staging API
+>     - this allows `nexus-staging-maven-plugin` to deploy through the new Sonatype Central Portal as a temporary (emergency) fallback; please migrate to the new profile and plugin as explained below
+>
+> ### What You Need to Do on Migration Day  
+>
+> ✅ If you use the default `maven-release-plugin` configuration:  
+> - upgrade this parent POM to `4.0.0` in your `pom.xml`
+> - no other changes needed, the new profile will be passed by default as an argument  
+>
+> ⚠️ If you explicitly use the `sonatype-oss-release` profile:  
+> - Switch to `central-sonatype-publish`  
+> - No further changes required
+>
+> 🚨 If you encounter issues with the new `central-sonatype-publish` profile:
+> - as a temporary fallback, you can continue using `sonatype-oss-release` with this parent POM in version `4.0.0`
+>     - it uses a partial reimplementation of the legacy staging API, exposed by Sonatype’s Central Portal, allowing the deprecated `nexus-staging-maven-plugin` to deploy artifacts
+>     - this fallback is not guaranteed and should only be used in case of emergency
+>     - please ensure:
+>         - the new default value of `nexus.sonatype.url` property is used: https://ossrh-staging-api.central.sonatype.com
+>         - `-Dsonatype-oss-release.acknowledge.deprecation=true` is set
+>         - `skipStaging` for `nexus-staging-maven-plugin` is not enabled
+>
+> 📍 If you consume SNAPSHOT artifacts, remember to update your repository URL as per Sonatype’s new [guidelines](https://central.sonatype.org/publish/publish-portal-snapshots/#consuming-snapshot-releases-for-your-project):  
+`https://central.sonatype.com/repository/maven-snapshots/`
+>
+> ### How to Review and Publish artifact Deployment
+>
+> With the new publishing flow, Maven will log a Deployment Id and a URL:
+>
+> ```log
+> Deployment xxxx-xxxx-xxxx-xxxx-xxxx has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
+> ```
+>
+> Visit the provided link to:
+> - ✅ Review validation results
+> - 🚀 Publish to Maven Central
+> - ❌ Drop the Deployment/bundle if needed
+> 
+> **Note:** Along with the deployment ID, a `${deploymentName}` is set with default value: `${project.groupId}:${project.artifactId}:${project.version}`
 
-Inherit the camunda-release-parent pom inside your project like so  
-  
-    <parent>
-      <groupId>org.camunda</groupId>
-      <artifactId>camunda-release-parent</artifactId>
-      <version>${LATEST_VERSION}</version>
-      <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-     <relativePath />
-    </parent>  
+This POM is meant to be inherited in Camunda release builds and defines common release properties. It supports deploying artifacts to two repositories at the same time:
+
+- [Camunda Artifactory](https://artifacts.camunda.com/)
+- [Maven Central](https://central.sonatype.com/publishing/deployments) via the Sonatype Central Portal
+
+Artifacts are deployed at the end of the build to reduce the chance of failure when interacting with external systems.
+
+
+## Usage
+
+Inherit the camunda-release-parent POM inside your project by adding the following:
+
+```xml 
+<parent>
+  <groupId>org.camunda</groupId>
+  <artifactId>camunda-release-parent</artifactId>
+  <version><!-- Use the newest version available! --></version>
+  <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
+  <relativePath />
+</parent>
+```
+
+If you have a multi-module build, simply inherit it in your parent POM.
+
+Specify the <scm> section for your project, eg:
+```xml    
+<scm>
+  <url>https://github.com/camunda/MY_PROJECT_URL</url>
+  <connection>scm:git:git@github.com:camunda/MY_PROJECT_URL.git</connection>
+  <developerConnection>scm:git:git@github.com:camunda/MY_PROJECT_URL.git</developerConnection>
+</scm>
+```
+
+## Release
+
+### Prerequisite
+
+Server credentials and your GPG passphrase (required for artifact signing when publishing to Maven Central) can be configured in your local `~/.m2/settings.xml` file.
+
+
+```xml  
+<settings>
+  <servers>
+    <server>
+      <id>camunda-nexus</id>
+      <username><!-- Camunda Nexus User (Artifactory) --></username>
+      <password><!-- Camunda Nexus Password (Artifactory) --></password>
+    </server>
+    <server>
+      <id>central</id>
+      <username><!-- Sonatype Central Portal User --></username>
+      <password><!-- Sonatype Central Portal Password --></password>
+    </server>
+  ...
+  </servers>  
+  <profiles>
+    <profile>
+      <id>central-sonatype-publish</id>
+      <properties>
+        <!-- GPG passphrase for signing artifacts.
+            It's safer to provide it at build time using:
+              mvn deploy -Dgpg.passphrase=...
+            Or use an environment variable:
+              <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+        -->
+        <gpg.passphrase><!-- GPG_PRIVATE_KEY_PASSPHRASE --></gpg.passphrase>
+      </properties>
+    </profile>
+    ...
+  </profiles>
+</settings>
+```
+
+### Deploy artifacts
+
+You can use the [Maven Release Plugin](https://maven.apache.org/maven-release/maven-release-plugin/) to prepare and deploy a new release of your project. For example:
+
+```bash
+mvn \
+  release:prepare release:perform \
+  -B -Dresume=false \
+  -Dtag=1.0.0 \
+  -DreleaseVersion=1.0.0 \
+  -DdevelopmentVersion=1.1.0-SNAPSHOT \
+  -Darguments="..."
+```
+
+This example runs both prepare and perform in a single step, but in practice, it's common to run them separately to review the changes in between.
+
+Use `-Darguments="..."` to pass additional command-line options to the Maven commands the release plugin runs internally. By default, the pluginManagement configuration includes `-P<a-default-sonatype-profile>` in these arguments.
     
-If you have a multi-module build, just inherit in your parent pom.  
-
-Specify the <scm> section for your project eg.
     
-    <scm>
-      <url>https://github.com/camunda/MY_PROJECT_URL</url>
-      <connection>scm:git:git@github.com:camunda/MY_PROJECT_URL.git</connection>
-      <developerConnection>scm:git:git@github.com:camunda/MY_PROJECT_URL.git</developerConnection>
-    </scm>
+### Override Default Settings
 
-Release
--------
-
-Prerequisite:  
-
-  Add the following to the profiles and servers section of your local settings.xml file. This allows the signing of your artifacts during the release. <strong>Mandatory for maven central</strong>.
-  
-    <settings>
-      ...
-      
-      <servers>
-        ...
-        
-        <server>
-          <id>camunda-nexus</id>
-          <username>MY_CAMUNDA_NEXUS_USER</username>
-          <password>MY_CAMUNDA_NEXUS_PASSWORD</password>
-        </server>
-        <server>
-          <id>central</id>
-          <username>MY_CENTRAL_USER</username>
-          <password>MY_CENTRAL_PASSWORD</password>
-        </server>
-        
-      </servers>
-      
-      
-      <profiles>
-        ...
-        
-        <profile>
-          <id>sonatype-oss-release</id>
-          <properties>
-            <gpg.passphrase>YOUR_SECRET_GPG_PASSPHRASE</gpg.passphrase>
-          </properties>
-        </profile>
-        
-      </profiles>
-    </settings>
-
-To release your own project use the following command:
-
-    mvn \
-    release:prepare release:perform \
-    -B -Dresume=false -Dtag=1.0.0 -DreleaseVersion=1.0.0 -DdevelopmentVersion=1.1.0-SNAPSHOT \
-    -Darguments="--settings=${PATH_TO_YOUR_SETTINGS_XML_FILE}" \
-    --settings=${PATH_TO_YOUR_SETTINGS_XML_FILE}
-    
-This will trigger the `sonatpye-oss-release` profile inside the `camunda-release-parent` pom automatically.
-    
-Customization
--------------
-
-You can override some default behaviours through the usage of the command line properties below. Add those properties to the `-Darguments="INSERT_PROPERTIES_HERE"` part of the Maven release command.
+You can override certain default settings using the properties listed below. To pass these to the release plugin, include them within the `-Darguments=...` option, as mentioned above.
 
 <table>
   <tr>
@@ -104,21 +188,21 @@ You can override some default behaviours through the usage of the command line p
   <tr>
     <td>serverId</td><td>Points to the corresponding entry in your settings.xml like <server><id>yourServerId</id></server> to specify your login credentials.<br/>Default is <strong>central</strong> for maven central.</td>
   </tr>
-  <tr>
-    <td>nexusUrl</td><td>The plain url which points to your nexus installation.<br/><strong>Must be a Nexus Enterprise Edition</strong><br/>Default is <strong>https://oss.sonatype.org</strong> aka maven central.</td>
-  </tr>
 </table>
 
-Testing
--------
+### Testing
 
 You can test your release steps by using the following Maven release command:
 
-    mvn \
-    release:prepare release:perform \
-    -B -Dresume=false -Dtag=1.0.0 -DreleaseVersion=1.0.0 -DdevelopmentVersion=1.1.0-SNAPSHOT \
-    -Darguments="--settings=${PATH_TO_YOUR_SETTINGS_XML_FILE} -Dskip.central.release=true -Dnexus.release.repository=${URL_OF_YOUR_LOCAL_NEXUS_REPOSITORY}" \
-    --settings=${PATH_TO_YOUR_SETTINGS_XML_FILE} \
-    -DpushChanges=false -DremoteTagging=false -DlocalCheckout=true
-    
-This will do a release but will not push anything to the involved git repositories and will not deploy to Maven Central. Instead it will deploy to a local Nexus repository. (Hint: You can use a simple Nexus Docker image to do so.)
+```bash
+mvn \
+release:prepare release:perform \
+--batch-mode \
+-DpushChanges=false -DremoteTagging=false \
+-DlocalCheckout=true -Dresume=false \
+-Dtag=1.0.0 -DreleaseVersion=1.0.0 -DdevelopmentVersion=1.1.0-SNAPSHOT \
+-Darguments="-Dskip.camunda.release=true -Dskip.central.release=true" \
+```
+
+This command performs a release without pushing changes to remote Git repositories or deploying artifacts.
+> Hint: You can use a Nexus Docker image to extend your testing by hosting a local repository.

--- a/pom.xml
+++ b/pom.xml
@@ -9,31 +9,37 @@
   <name>camunda - Release Parent Pom</name>
 
   <description>
-    This pom defines the required plugins and profiles to allow a camunda release build.
-    Inherit this pom when you want to release your project into the camunda nexus and/or maven central.
+    This POM defines the plugins and profiles needed for Camunda release builds.
+    Inherit this POM when you want to release your project to the Camunda Nexus and/or Maven Central.
   </description>
 
   <properties>
+    <!-- Encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Avoid the message "[WARNING] Using platform encoding (UTF-8 actually) ... also for the failsafe plugin -->
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- we use java 1.7 for our projects -->
-    <version.java>1.7</version.java>
-    <version.ejb>3.1</version.ejb>
+    <!-- Java version -->
+    <version.java>1.7</version.java> <!-- Legacy -->
+    <version.ejb>3.1</version.ejb> <!-- Legacy -->
 
+    <!-- Camunda (Nexus) Artifactory -->
     <skip.camunda.release>false</skip.camunda.release>
-    <skip.central.release>false</skip.central.release>
     <nexus.snapshot.repository.id>camunda-nexus</nexus.snapshot.repository.id>
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots</nexus.snapshot.repository>
     <nexus.release.repository.id>camunda-nexus</nexus.release.repository.id>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-bpm</nexus.release.repository>
-
     <nexus.staging.deploy.id>camunda-nexus</nexus.staging.deploy.id>
     <nexus.staging.deploy.url>https://artifacts.camunda.com/artifactory</nexus.staging.deploy.url>
-    <nexus.sonatype.url>https://oss.sonatype.org</nexus.sonatype.url>
+    
+    <!-- Sonatype Central  -->
+    <skip.central.release>false</skip.central.release>
+    <nexus.sonatype.url>https://oss.sonatype.org</nexus.sonatype.url> <!-- Deprecated: used by sonatype-oss-release deprecated profile, to be removed in future versions-->
+
+    <!-- Maven GPG plugin -->
     <gpg.useagent>true</gpg.useagent>
 
+    <!-- Plugin versions -->
     <plugin.version.clean>3.1.0</plugin.version.clean>
     <plugin.version.source>3.2.1</plugin.version.source>
     <plugin.version.compiler>3.8.1</plugin.version.compiler>
@@ -41,8 +47,6 @@
     <plugin.version.jar>2.6</plugin.version.jar>
     <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
     <plugin.version.maven-bundle>5.1.2</plugin.version.maven-bundle>
-
-
     <plugin.version.deploy>2.8.2</plugin.version.deploy>
     <plugin.version.assembly>3.3.0</plugin.version.assembly>
     <plugin.version.ejb>3.1.0</plugin.version.ejb>
@@ -52,6 +56,7 @@
     <plugin.version.gpg>3.0.1</plugin.version.gpg>
     <plugin.version.release>2.5.3</plugin.version.release>
     <plugin.version.nexus-staging>1.6.13</plugin.version.nexus-staging>
+    <plugin.version.central-publishing>0.7.0</plugin.version.central-publishing>
   </properties>
 
   <build>
@@ -70,6 +75,11 @@
             <source>${version.java}</source>
             <target>${version.java}</target>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -163,6 +173,11 @@
           <configuration>
             <skip>true</skip>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${plugin.version.central-publishing}</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
@@ -274,8 +289,112 @@
         <nexus.release.repository.id>${env.NEXUS_RELEASE_REPOSITORY_ID}</nexus.release.repository.id>
       </properties>
     </profile>
-    <!-- activate this profile to release to maven central -->
+      <!--
+      This profile configures environment for the publication using the central publishing plugin
+      into Maven Central Publisher Portal via https://central.sonatype.org/publish/publish-portal-maven/
+      -->
     <profile>
+      <id>central-sonatype-publish</id>
+      <properties>
+        <serverId>central</serverId>
+        <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+      </properties>      
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                <arguments>${arguments}</arguments>
+              </configuration>
+              </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${plugin.version.source}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>attach-test-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>test-jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${plugin.version.javadoc}</version>
+            <configuration>
+              <quiet>true</quiet>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${plugin.version.gpg}</version>
+            <configuration>
+              <passphrase>${gpg.passphrase}</passphrase>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>central-deploy</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>publish</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <autoPublish>false</autoPublish>
+              <deploymentName>${deploymentName}</deploymentName>
+              <failOnBuildFailure>true</failOnBuildFailure>
+              <publishingServerId>${serverId}</publishingServerId>
+              <skipPublishing>${skip.central.release}</skipPublishing>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!--
+      This profile configures environment for the publication using the nexus staging plugin into
+      OSS Nexus repository.
+      -->
       <id>sonatype-oss-release</id>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,33 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>warn-deprecated-profile</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <evaluateBeanshell>
+                      <condition>false</condition>
+                      <message>
+⚠️ Deprecated Profile Notice: The sonatype-oss-release profile is deprecated and will be removed in a future release.
+
+A new profile, central-sonatype-publish, is available for use with the new Sonatype Central Portal publishing interface.
+Please refer to the documentation for migration guidance:
+https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file#%EF%B8%8F-migration-to-sonatype-central-portal
+                      </message>
+                    </evaluateBeanshell>
+                  </rules>
+                  <fail>false</fail>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR introduces a new `central-sonatype-publish` Maven profile, intended for deploying artifacts via the Sonatype Central Portal as part of the upcoming migration from OSSRH.

Additionally:
- a deprecation warning has been added for the existing `sonatype-oss-release` profile. This warning includes a link to relevant documentation to help users understand the change
- `README.md` has been updated including migration guidance