### PR TITLE
[Backport 3.x] feat: add central-sonatype-publish profile for Sonatype Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <plugin.version.gpg>1.4</plugin.version.gpg>
     <plugin.version.release>2.5.3</plugin.version.release>
     <plugin.version.nexus-staging>1.6.8</plugin.version.nexus-staging>
+    <plugin.version.central-publishing>0.7.0</plugin.version.central-publishing>
   </properties>
 
   <build>
@@ -68,6 +69,11 @@
             <source>${version.java}</source>
             <target>${version.java}</target>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -161,6 +167,11 @@
           <configuration>
             <skip>true</skip>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${plugin.version.central-publishing}</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
@@ -274,6 +285,104 @@
     </profile>
     <!-- activate this profile to release to maven central -->
     <profile>
+      <id>central-sonatype-publish</id>
+      <properties>
+        <serverId>central</serverId>
+        <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+      </properties>  
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                <arguments>${arguments}</arguments>
+              </configuration>
+              </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${plugin.version.source}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>attach-test-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>test-jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${plugin.version.javadoc}</version>
+            <configuration>
+              <quiet>true</quiet>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${plugin.version.gpg}</version>
+            <configuration>
+              <passphrase>${gpg.passphrase}</passphrase>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>central-deploy</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>publish</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <autoPublish>false</autoPublish>
+              <deploymentName>${deploymentName}</deploymentName>
+              <failOnBuildFailure>true</failOnBuildFailure>
+              <publishingServerId>${serverId}</publishingServerId>
+              <skipPublishing>${skip.central.release}</skipPublishing>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- activate this profile to release to maven central -->
+    <profile>
       <id>sonatype-oss-release</id>
       <build>
         <plugins>
@@ -350,6 +459,33 @@
                   <nexusUrl>https://oss.sonatype.org</nexusUrl>
                   <skipStaging>false</skipStaging>
                   <skipNexusStagingDeployMojo>${skip.central.release}</skipNexusStagingDeployMojo>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>warn-deprecated-profile</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <evaluateBeanshell>
+                      <condition>false</condition>
+                      <message>
+⚠️ Deprecated Profile Notice: The sonatype-oss-release profile is deprecated and will be removed in a future release.
+
+A new profile, central-sonatype-publish, is available for use with the new Sonatype Central Portal publishing interface.
+Please refer to the documentation for migration guidance:
+https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file#%EF%B8%8F-migration-to-sonatype-central-portal
+                      </message>
+                    </evaluateBeanshell>
+                  </rules>
+                  <fail>false</fail>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Backport https://github.com/camunda/camunda-release-parent/pull/52 to `3.x` branch.

Related to https://github.com/camunda/team-infrastructure/issues/833.