### PR TITLE
[Backport 3.x] chore: update parent POM in sync with migration to Sonatype Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
-            <arguments>${arguments} -Psonatype-oss-release</arguments>
+            <arguments>${arguments} -Pcentral-sonatype-publish</arguments>
           </configuration>
         </plugin>
         <plugin>
@@ -291,17 +291,6 @@
         <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
       </properties>  
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-release-plugin</artifactId>
-              <configuration>
-                <arguments>${arguments}</arguments>
-              </configuration>
-              </plugin>
-          </plugins>
-        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -385,6 +374,17 @@
     <profile>
       <id>sonatype-oss-release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                <arguments>${arguments}</arguments>
+              </configuration>
+              </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -456,7 +456,7 @@
                   <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
                   <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
                   <serverId>central</serverId>
-                  <nexusUrl>https://oss.sonatype.org</nexusUrl>
+                  <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
                   <skipStaging>false</skipStaging>
                   <skipNexusStagingDeployMojo>${skip.central.release}</skipNexusStagingDeployMojo>
                 </configuration>
@@ -486,6 +486,87 @@ https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file
                     </evaluateBeanshell>
                   </rules>
                   <fail>false</fail>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fail-deprecated-profile-zeebe-no-ackn</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <evaluateBeanshell>
+                        <condition><![CDATA[
+                          !"${project.groupId}".startsWith("io.zeebe") ||
+                          "${sonatype-oss-release.acknowledge.deprecation}".equals("true")
+                          ]]>
+                        </condition>
+                        <message>
+❌ Deployment Blocked: Publishing under the io.zeebe namespace using the deprecated sonatype-oss-release profile is no longer supported.
+To deploy to Maven Central, please use the  profile, which supports the new Central Portal publishing interface.
+
+🛑 To bypass this check (not recommended), you may pass -Dsonatype-oss-release.acknowledge.deprecation=true.
+
+Please refer to the documentation for migration guidance and namespace-specific rollout details:
+https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file#%EF%B8%8F-migration-to-sonatype-central-portal
+                        </message>
+                      </evaluateBeanshell>
+                    </rules>
+                  <fail>true</fail>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fail-deprecated-profile-io-camunda-no-ackn</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <evaluateBeanshell>
+                        <condition><![CDATA[
+                          !"${project.groupId}".startsWith("io.camunda") ||
+                          "${sonatype-oss-release.acknowledge.deprecation}".equals("true")
+                          ]]>
+                        </condition>
+                        <message>
+❌ Deployment Blocked: Publishing under the io.camunda namespace using the deprecated sonatype-oss-release profile is no longer supported.
+To deploy to Maven Central, please use the  profile, which supports the new Central Portal publishing interface.
+
+🛑 To bypass this check (not recommended), you may pass -Dsonatype-oss-release.acknowledge.deprecation=true.
+
+Please refer to the documentation for migration guidance and namespace-specific rollout details:
+https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file#%EF%B8%8F-migration-to-sonatype-central-portal
+                        </message>
+                      </evaluateBeanshell>
+                    </rules>
+                  <fail>true</fail>
+                </configuration>
+              </execution>
+              <execution>
+                <id>fail-deprecated-profile-org-camunda-no-ackn</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <evaluateBeanshell>
+                        <condition><![CDATA[
+                          !"${project.groupId}".startsWith("org.camunda") ||
+                          "${sonatype-oss-release.acknowledge.deprecation}".equals("true")
+                          ]]>
+                        </condition>
+                        <message>
+❌ Deployment Blocked: Publishing under the org.camunda namespace using the deprecated sonatype-oss-release profile is no longer supported.
+To deploy to Maven Central, please use the  profile, which supports the new Central Portal publishing interface.
+
+🛑 To bypass this check (not recommended), you may pass -Dsonatype-oss-release.acknowledge.deprecation=true.
+
+Please refer to the documentation for migration guidance and namespace-specific rollout details:
+https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file#%EF%B8%8F-migration-to-sonatype-central-portal
+                        </message>
+                      </evaluateBeanshell>
+                    </rules>
+                  <fail>true</fail>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Backport https://github.com/camunda/camunda-release-parent/pull/53 to `3.x` branch.

Related to https://github.com/camunda/team-infrastructure/issues/833.