### PR TITLE
fix: bump maven version to 3.3

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,6 +1,7 @@
 @Library("camunda-ci") _
 buildMavenAndDeployToMavenCentral([
   jdk:8,
+  mvn: 3.3,
   mvnReleaseProfiles:'sonatype-oss-release',
   publishZipArtifactToCamundaOrg:true
 ])


### PR DESCRIPTION
Makes `nexus-staging-maven-plugin` plugin work with maven 3.3 and http://ossrh-staging-api.central.sonatype.com/. It does not work with maven 3.2.

Test: https://stage.ci.cambpm.camunda.cloud/job/camunda-github-org/job/camunda-release-parent/job/infra-833-fix-release-pipeline/24/console

Related to https://camunda.slack.com/archives/CHY2S7KDJ/p1750663870410129.