### PR TITLE
Backport 57 to 3.x

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,5 @@
 @Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk:8])
+buildMavenAndDeployToMavenCentral([
+  jdk:8,
+  mvn:3.3
+])

--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,5 +1,6 @@
 @Library("camunda-ci") _
 buildMavenAndDeployToMavenCentral([
   jdk:8,
-  mvn:3.3
+  mvn:3.3,
+  mvnReleaseProfiles:'sonatype-oss-release'
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.camunda</groupId>
   <artifactId>camunda-release-parent</artifactId>
-  <version>4.0.400</version>
+  <version>4.0.401-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>camunda - Release Parent Pom</name>
 
@@ -603,7 +603,7 @@ https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file
     <url>https://github.com/camunda/camunda-release-parent</url>
     <connection>scm:git:git@github.com:camunda/camunda-release-parent.git</connection>
     <developerConnection>scm:git:git@github.com:camunda/camunda-release-parent.git</developerConnection>
-    <tag>4.0.400</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.camunda</groupId>
   <artifactId>camunda-release-parent</artifactId>
-  <version>3.7.4-SNAPSHOT</version>
+  <version>4.0.400</version>
   <packaging>pom</packaging>
   <name>camunda - Release Parent Pom</name>
 
@@ -603,7 +603,7 @@ https://github.com/camunda/camunda-release-parent/tree/master?tab=readme-ov-file
     <url>https://github.com/camunda/camunda-release-parent</url>
     <connection>scm:git:git@github.com:camunda/camunda-release-parent.git</connection>
     <developerConnection>scm:git:git@github.com:camunda/camunda-release-parent.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>4.0.400</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
Backport of https://github.com/camunda/camunda-release-parent/pull/57 to the `3.x` branch.

It also uses the deprecated `sonatype-oss-release` profile as a fallback, since central-publishing-maven-plugin does not work with maven `3.3`.

Test: https://stage.ci.cambpm.camunda.cloud/job/camunda-github-org/job/camunda-release-parent/job/backport-57-to-3.x/3/console