### PR TITLE
feat(sonatype): add central.sonatype.deployment.name property to customize deployment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 > - 🚀 Publish to Maven Central
 > - ❌ Drop the Deployment/bundle if needed
 > 
-> **Note:** Along with the deployment ID, a `${deploymentName}` is set with default value: `${project.groupId}:${project.artifactId}:${project.version}`
+> **Note:** Along with the deployment ID, a deployment name is set by default to `Deployment`, unless the maven-release-plugin is used. In that case, the deployment name is automatically set to `${project.groupId}:${project.artifactId}:${project.version}` from the top-level project where the release is performed. Users can override the deployment name at any time by configuring the `central.sonatype.deployment.name` property in their top-level module.
 
 This POM is meant to be inherited in Camunda release builds and defines common release properties. It supports deploying artifacts to two repositories at the same time:
 

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,12 @@
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
-            <arguments>${arguments} -Pcentral-sonatype-publish</arguments>
+            <!-- 
+              This ensures that the deployment name in the Sonatype Central Portal for projects using the maven-release-plugin 
+              is set by default to the top-level module’s groupId, artifactId, and version.
+              deploymentName is superseded if the central.sonatype.deployment.name property is set.
+            -->
+            <arguments>${arguments} -Pcentral-sonatype-publish -DdeploymentName=${project.groupId}:${project.artifactId}:${project.version}</arguments>
           </configuration>
         </plugin>
         <plugin>
@@ -297,7 +302,16 @@
       <id>central-sonatype-publish</id>
       <properties>
         <serverId>central</serverId>
-        <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+        <!-- 
+          deploymentName is redundant with central.sonatype.deployment.name but is kept for backward compatibility.
+          It is now only meant to be used in the arguments of the maven-release-plugin (currently appended by default, see configuration).  
+        -->
+        <deploymentName>Deployment</deploymentName>
+        <!-- 
+          If central.sonatype.deployment.name is set, it always takes precedence over deploymentName.
+          This is the property that child POMs inheriting from this POM should use to override the deployment name in the Sonatype Central Portal.
+        -->
+        <central.sonatype.deployment.name>${deploymentName}</central.sonatype.deployment.name>
       </properties>      
       <build>
         <plugins>
@@ -371,7 +385,7 @@
             <configuration>
               <autoPublish>false</autoPublish>
               <checksums>required</checksums>
-              <deploymentName>${deploymentName}</deploymentName>
+              <deploymentName>${central.sonatype.deployment.name}</deploymentName>
               <failOnBuildFailure>true</failOnBuildFailure>
               <publishingServerId>${serverId}</publishingServerId>
               <skipPublishing>${skip.central.release}</skipPublishing>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR introduces a new standardized property to define the deployment name in the Sonatype Central Portal: `central.sonatype.deployment.name`

The behavior is configured as follows:
- by default, the deployment name is set to Deployment to avoid ambiguity.
- when the maven-release-plugin is used to perform the release, the deployment name is automatically overridden to the top-level module’s `groupId:artifactId:version`.
- regardless of whether the maven-release-plugin is used or not, the deployment name can be explicitly overridden by setting the `${central.sonatype.deployment.name}` property

The `${central.sonatype.deployment.name}` property must be defined in the top-level module to be inherited by all modules in a multi-module project.

The existing `deploymentName` property remains for backward compatibility and used to configure a correct default deployment name when using the `maven-release-plugin`.

#### Why
In multi-module projects, the `groupId:artifactId:version` expression resolve based on the last module in the reactor build order, where the entire bundle is deployed.
This can cause confusion because the resolved values might not correspond to the top-level module’s artifactId.

#### Notes
For projects not using the `maven-release-plugin`, the deployment name will change from a seemingly “random” `groupId:artifactId:version` format to `Deployment`. This removes ambiguity while still allowing users to specify a custom deployment name via the new `central.sonatype.deployment.name` property.
Since the migration to the Sonatype Central Portal is recent, this change will mostly go unnoticed. I will set appropriate deployment names for the main repositories (CamBPM and Connectors).

Once merged:
- [ ] backport commit to the 3.x` branch