### PR TITLE
chore(central-publishing-maven-plugin): generate only the required checksums for artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,7 @@
             </executions>
             <configuration>
               <autoPublish>false</autoPublish>
+              <checksums>required</checksums>
               <deploymentName>${deploymentName}</deploymentName>
               <failOnBuildFailure>true</failOnBuildFailure>
               <publishingServerId>${serverId}</publishingServerId>


### PR DESCRIPTION
Related to  https://github.com/camunda/team-infrastructure/issues/833.

By default, the `central-publishing-maven-plugin` generates "all" [checksums](https://central.sonatype.org/publish/publish-portal-maven/#checksums) (MD5, SHA1, SHA256 and SHA512) for the files to be deployed (e.g. https://repo1.maven.org/maven2/io/camunda/connector/connector-runtime-bundle/8.7.5-rc1/). Only MD5 and SHA1 are required.

SHA-256 and SHA-512 checksums were not generated prior to the Sonatype Central Portal migration. There is no explicit requirement to provide these checksums, and publishing them would unnecessarily consume storage space, increase upload time, etc ... . Therefore, we should not generate or publish them.