### PR TITLE
deps: upgrade central-publishing-maven-plugin to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <plugin.version.gpg>3.0.1</plugin.version.gpg>
     <plugin.version.release>2.5.3</plugin.version.release>
     <plugin.version.nexus-staging>1.6.13</plugin.version.nexus-staging>
-    <plugin.version.central-publishing>0.7.0</plugin.version.central-publishing>
+    <plugin.version.central-publishing>0.8.0</plugin.version.central-publishing>
   </properties>
 
   <build>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

Upgrade central-publishing-maven-plugin to 0.8.0. No breaking changes reported, see the [release note](https://central.sonatype.org/publish/publish-portal-maven/#080).

Tested locally.
