### PR TITLE
fix: use built-in release plugin property releaseVersion to set deployment name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
               is set by default to the top-level module’s groupId, artifactId, and version.
               deploymentName is superseded if the central.sonatype.deployment.name property is set.
             -->
-            <arguments>${arguments} -Pcentral-sonatype-publish -DdeploymentName=${project.groupId}:${project.artifactId}:${project.version}</arguments>
+            <arguments>${arguments} -Pcentral-sonatype-publish -DdeploymentName=${project.groupId}:${project.artifactId}:${releaseVersion}</arguments>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

`${project.version}` in maven-release-plugin arguments reflects the current build version (this a *-SNAPSHOT), not the final release version.
This PR introduces the release plugin property `${releaseVersion}` to reference the actual release version during execution.
