### PR TITLE
[Backport 3.x] fix: use built-in release plugin property releaseVersion to set deployment name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
               is set by default to the top-level module’s groupId, artifactId, and version.
               deploymentName is superseded if the central.sonatype.deployment.name property is set.
             -->
-            <arguments>${arguments} -Pcentral-sonatype-publish -DdeploymentName=${project.groupId}:${project.artifactId}:${project.version}</arguments>
+            <arguments>${arguments} -Pcentral-sonatype-publish -DdeploymentName=${project.groupId}:${project.artifactId}:${releaseVersion}</arguments>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Backport https://github.com/camunda/camunda-release-parent/pull/63 to `3.x`.